### PR TITLE
Check file ownership and permission for dirsrv log instance

### DIFF
--- a/ipatests/test_integration/test_backup_and_restore.py
+++ b/ipatests/test_integration/test_backup_and_restore.py
@@ -29,6 +29,7 @@ from tempfile import NamedTemporaryFile
 from ipaplatform.constants import constants
 from ipaplatform.paths import paths
 from ipaplatform.tasks import tasks as platformtasks
+from ipaserver.install.installutils import realm_to_serverid
 from ipapython.dn import DN
 from ipapython import ipautil
 from ipatests.test_integration.base import IntegrationTest
@@ -173,6 +174,15 @@ class TestBackupAndRestore(IntegrationTest):
             dirman_password = self.master.config.dirman_password
             self.master.run_command(['ipa-restore', backup_path],
                                     stdin_text=dirman_password + '\nyes')
+
+            # check the file permssion and ownership is set to 770 and
+            # dirsrv:dirsrv after restore on /var/log/dirsrv/slapd-<instance>
+            # related ticket : https://pagure.io/freeipa/issue/7725
+            instance = realm_to_serverid(self.master.domain.realm)
+            log_path = paths.VAR_LOG_DIRSRV_INSTANCE_TEMPLATE % instance
+            cmd = self.master.run_command(['stat', '-c',
+                                           '"%a %G:%U"', log_path])
+            assert "770 dirsrv:dirsrv" in cmd.stdout_text
 
     def test_full_backup_and_restore_with_removed_users(self):
         """regression test for https://fedorahosted.org/freeipa/ticket/3866"""


### PR DESCRIPTION
Check if file ownership and permission is set to dirsrv:dirsrv
and 770 on /var/log/dirsrv/slapd-<instance> after ipa-restore.

related ticket : https://pagure.io/freeipa/issue/7725

Signed-off-by: Mohammad Rizwan Yusuf <myusuf@redhat.com>